### PR TITLE
feat(player): don't collide with recruited beople

### DIFF
--- a/Assets/Prefabs/Chicken.prefab
+++ b/Assets/Prefabs/Chicken.prefab
@@ -61,13 +61,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &8597187419404964772
 GameObject:
   m_ObjectHideFlags: 0
@@ -77,7 +77,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6347027245232290051}
-  - component: {fileID: 7363642158096774243}
   - component: {fileID: 8672716160627977305}
   - component: {fileID: 6273559484431445267}
   - component: {fileID: 9145589377480195564}
@@ -95,27 +94,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8597187419404964772}
-  m_LocalRotation: {x: -0.16274357, y: 0, z: -0, w: -0.9866684}
+  m_LocalRotation: {x: -0.03850429, y: 0, z: -0, w: -0.99925846}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 4217522848954397997}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &7363642158096774243
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8597187419404964772}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &8672716160627977305
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -156,7 +141,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 50909e49d39f79c4b9ef3cdfb74186fa, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 37eb6590c939cfe48b4dbabb7cb72c06, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/ChickenLeader.prefab
+++ b/Assets/Prefabs/ChickenLeader.prefab
@@ -61,13 +61,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &4516825867596015430
 GameObject:
   m_ObjectHideFlags: 0
@@ -77,7 +77,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1293816208973876705}
-  - component: {fileID: 3445619702812819585}
   - component: {fileID: 3583185522740762811}
   - component: {fileID: 2229717525981927921}
   - component: {fileID: 3965995955916294414}
@@ -95,27 +94,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4516825867596015430}
-  m_LocalRotation: {x: -0.13523231, y: 0, z: -0, w: -0.9908139}
+  m_LocalRotation: {x: -0.008111176, y: -0, z: -0, w: 0.9999671}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 8315338116869718479}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &3445619702812819585
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4516825867596015430}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &3583185522740762811
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Magpie.prefab
+++ b/Assets/Prefabs/Magpie.prefab
@@ -61,13 +61,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &4286306674625626433
 GameObject:
   m_ObjectHideFlags: 0
@@ -77,7 +77,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1451978751384398822}
-  - component: {fileID: 3027462226208859782}
   - component: {fileID: 3776532412509486780}
   - component: {fileID: 1955534486950445046}
   - component: {fileID: 3663946890433507081}
@@ -95,27 +94,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4286306674625626433}
-  m_LocalRotation: {x: -0.13032469, y: 0, z: -0, w: -0.9914714}
+  m_LocalRotation: {x: -0.0073331366, y: -0, z: -0, w: 0.9999731}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 8553738609191053256}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &3027462226208859782
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4286306674625626433}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &3776532412509486780
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/MagpieLeader.prefab
+++ b/Assets/Prefabs/MagpieLeader.prefab
@@ -61,13 +61,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!114 &907510874844850229
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -96,7 +96,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5959911522629839244}
-  - component: {fileID: 7822780944265438444}
   - component: {fileID: 8285318403654499542}
   - component: {fileID: 6751134752843087260}
   - component: {fileID: 8379889665189801315}
@@ -114,27 +113,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9074656755694633771}
-  m_LocalRotation: {x: -0.10967124, y: 0, z: -0, w: -0.99396795}
+  m_LocalRotation: {x: -0.004557506, y: 0, z: -0, w: -0.9999896}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 3469837672486610338}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -0.09, y: 0, z: 0.251}
---- !u!136 &7822780944265438444
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9074656755694633771}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &8285318403654499542
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Pigeon.prefab
+++ b/Assets/Prefabs/Pigeon.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4238070161203943386}
-  - component: {fileID: 357302224856505018}
   - component: {fileID: 1918006329997296256}
   - component: {fileID: 3879187942247498698}
   - component: {fileID: 2030601064771703605}
@@ -27,27 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1552287860888092029}
-  m_LocalRotation: {x: -0.10999044, y: 0, z: -0, w: -0.99393266}
+  m_LocalRotation: {x: -0.0038606888, y: -0, z: -0, w: 0.99999255}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 6359693256001887220}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &357302224856505018
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1552287860888092029}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &1918006329997296256
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -191,13 +176,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1001 &3810243318289228848
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -39,7 +39,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7511297806933570520}
-  - component: {fileID: 7511297806933570521}
   - component: {fileID: 2548625093102466172}
   - component: {fileID: 295875141122373696}
   - component: {fileID: 1115558936372115991}
@@ -57,27 +56,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7511297806933570527}
-  m_LocalRotation: {x: -0.56279814, y: 0, z: -0, w: -0.8265944}
+  m_LocalRotation: {x: -0.11954727, y: 0, z: -0, w: -0.99282855}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 7511297808730203070}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &7511297806933570521
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7511297806933570527}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &2548625093102466172
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -118,7 +103,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 248f07df39f8a9342a6e17d0e7e99dec, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 85d846c4db8f08a4087be1bdb20b6f0f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -288,13 +273,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!114 &7511297808730203068
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,3 +308,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SquawkRadius: 12.5
   SquawkCooldown: 2
+  recruitedBeopleVar: {fileID: 0}

--- a/Assets/Prefabs/Sparrow.prefab
+++ b/Assets/Prefabs/Sparrow.prefab
@@ -61,13 +61,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &7938614910808954686
 GameObject:
   m_ObjectHideFlags: 0
@@ -77,7 +77,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4715783371999935897}
-  - component: {fileID: 9174977978793652473}
   - component: {fileID: 7007413274122725571}
   - component: {fileID: 5653373538831542665}
   - component: {fileID: 7462272504170477942}
@@ -95,27 +94,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7938614910808954686}
-  m_LocalRotation: {x: -0.09463116, y: 0, z: -0, w: -0.9955124}
+  m_LocalRotation: {x: -0.021922247, y: -0, z: -0, w: 0.9997597}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 2586015015562719671}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &9174977978793652473
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7938614910808954686}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &7007413274122725571
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/SparrowLeader.prefab
+++ b/Assets/Prefabs/SparrowLeader.prefab
@@ -61,13 +61,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &7788418046810964055
 GameObject:
   m_ObjectHideFlags: 0
@@ -77,7 +77,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4849381999706909424}
-  - component: {fileID: 9036953267028699024}
   - component: {fileID: 7134530839164682154}
   - component: {fileID: 5497054040073076448}
   - component: {fileID: 7328189541455834655}
@@ -95,27 +94,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7788418046810964055}
-  m_LocalRotation: {x: -0.08354015, y: 0, z: -0, w: -0.9965044}
+  m_LocalRotation: {x: -0.022033408, y: -0, z: -0, w: 0.99975723}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 2440663154015528670}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -0.09, y: 0, z: 0.251}
---- !u!136 &9036953267028699024
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7788418046810964055}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &7134530839164682154
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Tet.prefab
+++ b/Assets/Prefabs/Tet.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2897547030819142630}
-  - component: {fileID: 1590867490203727494}
   - component: {fileID: 610415247894294204}
   - component: {fileID: 2824642168699498486}
   - component: {fileID: 1065282867161431817}
@@ -27,27 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 534895237800825153}
-  m_LocalRotation: {x: -0.05586114, y: 0, z: -0, w: -0.99843854}
+  m_LocalRotation: {x: -0.008139729, y: -0, z: -0, w: 0.99996686}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1.2, y: 1.8, z: 1.2}
   m_Children: []
   m_Father: {fileID: 5378611482583414728}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1590867490203727494
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 534895237800825153}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!212 &610415247894294204
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -191,13 +176,13 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 4
   m_Radius: 0.5
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1001 &5829711073836617318
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BirdController.cs
+++ b/Assets/Scripts/BirdController.cs
@@ -40,6 +40,13 @@ public class BirdController : MonoBehaviour
 		IsRecruited = true;
 		recruitedBeopleVar.currentNum += 1;
 		collectParticles.Play();
+
+		// Allow the player to pass through recruited beople
+		GameObject player = GameObject.FindGameObjectWithTag("Player");
+		Collider playerCollider = player.GetComponent<Collider>();
+		Collider bersonCollider = GetComponent<Collider>();
+		Physics.IgnoreCollision(bersonCollider, playerCollider);
+
 		Debug.Log("Recruited Berson!");
 		Debug.Log(recruitedBeopleVar.currentNum);
 		return true;


### PR DESCRIPTION
The problem was that each Berson prefab had two Capsule Colliders on it -- one explicit one attached to the GFX child and one implicit one that comes with the Character Controller attached to the root GameObject. I deleted the child Capsule Collider and reconfigured the one on the Character Controller to do what we want.