### PR TITLE
feat: squawk for leaders, adjust bird follower speed

### DIFF
--- a/Assets/Scripts/BirdController.cs
+++ b/Assets/Scripts/BirdController.cs
@@ -6,9 +6,9 @@ public class BirdController : MonoBehaviour
 {
 	CharacterController characterController;
 	public GameObject player;
+	private ThirdPersonMovement movementScript;
 
 	public bool IsRecruited = false;
-	[SerializeField] private float speed = 5.0f;
 	[SerializeField] private float playerBufferDistance = 6.0f;
 
 	[SerializeField] private VarObject recruitedBeopleVar;
@@ -20,6 +20,7 @@ public class BirdController : MonoBehaviour
 	void Start()
 	{
 		player = GameObject.FindWithTag("Player");
+		movementScript = player.GetComponent<ThirdPersonMovement>();
 	}
 
 	// Update is called once per frame
@@ -54,9 +55,9 @@ public class BirdController : MonoBehaviour
 	}
 
 	public void MoveTowardsPlayer()
-	{
+	{	
 		float dist = Vector3.Distance(player.transform.position, transform.position);
-		float step = speed * Time.deltaTime;
+		float step = movementScript.speed * Time.deltaTime;
 
 		if (dist > playerBufferDistance)
 		{

--- a/Assets/Scripts/BirdLeaderController.cs
+++ b/Assets/Scripts/BirdLeaderController.cs
@@ -6,20 +6,6 @@ public class BirdLeaderController : BirdController
 {
     public Dialogue dialogue;
 
-    void Update()
-    {
-        if (!IsRecruited) {
-            float dist = Vector3.Distance(player.transform.position, transform.position);
-
-            if (dist < 5 && Input.GetKeyDown(KeyCode.E)) {
-                TriggerDialogue();
-            }
-        }
-
-        else
-			MoveTowardsPlayer();
-    }
-
     public void TriggerDialogue()
     {
         FindObjectOfType<DialogueManager>().StartDialogue(dialogue, this);

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -54,18 +54,29 @@ public class PlayerController : MonoBehaviour
 		SquawkGfx.GetComponent<AudioSource>().Play();
 
 		GameObject[] beople = GameObject.FindGameObjectsWithTag("Berson");
+		GameObject[] leaders = GameObject.FindGameObjectsWithTag("BersonLeader");
+
 		foreach (GameObject berson in beople)
 		{
 			float distance = Vector3.Distance(transform.position, berson.transform.position);
 			if (distance <= SquawkRadius)
 			{
-				bool recruited = berson.GetComponent<BirdController>().Recruit();
-				if (recruited)
-				{
-					HandleRecruitment(berson);
-				}
+				berson.GetComponent<BirdController>().Recruit();
 			}
 		}
+
+		foreach (GameObject leader in leaders)
+		{
+			float distance = Vector3.Distance(transform.position, leader.transform.position);
+			BirdLeaderController leaderController = leader.GetComponent<BirdLeaderController>();
+			if (distance <= SquawkRadius && !leaderController.IsRecruited)
+			{
+				leaderController.TriggerDialogue();
+				HandleRecruitment(leader);
+				return;
+			}
+		}
+		
 
 		LastSquawkTime = Time.time;
 	}


### PR DESCRIPTION
* triggering dialogue with the bird leaders now  happens via squawking and having them within your squawk radius, no more E to talk
* this fixes a bug where recruiting bird leader wasn't updating your stats, but now that the recruitment is handled in the player controller, you now get the expected stat boosts
* to allow the bird followers to follow you, especially after you speed up, they now match your character's speed